### PR TITLE
Fixed up arrow in chrome

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -706,7 +706,8 @@
           break;
         case 38: // up-arrow
           if (historycursor > 0) {
-            DOM.guessbox.val(historyvalues[--historycursor]);
+            DOM.guessbox.val(historyvalues[--historycursor]); 
+	    return false;
           }
           break;
         case 40: // down-arrow


### PR DESCRIPTION
Jumps now at the end of the value by returning false so it prevents default action
