### PR TITLE
Added checks if node/uglifyjs is properly installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Unless previously installed you'll need the following packages:
 
 Please use their sites to get detailed installation instructions.
 
+#####Possible Errors
+    /usr/bin/env: node: No such file or directory
+Make sure you have Node.js installed. Some package managers name the binary nodejs. You can symlink it to make it work.
+`sudo ln -s /usr/bin/nodejs /usr/bin/node`
+
 You also need `UglifyJS` installed globally:
 
     $ npm install uglify-js -g


### PR DESCRIPTION
I ran into an issue when apt-get calls the bin nodejs instead of node
symlinking resolves that issue. Uglifyjs also breaks if it's called nodejs
