### PR TITLE
times for users getting +3 on a song

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1047,8 +1047,10 @@
 
         $username.addClass('correct');
 
-        if (user.roundpoints > 3) {
+        if (user.roundpoints > 2) {
           $guesstime.text((user.guesstime / 1000).toFixed(1) +' s');
+        }
+        if (user.roundpoints > 3) {
           $roundrank.addClass('icons round-rank stand' + (7 - user.roundpoints));
         }
       }


### PR DESCRIPTION
this should show times on leaderboard for users who get +3 on a song, like when you get +4 or more it says the time next to your name on the leaderboard, but not when you get +3. this is the first time i've ever used github so i'm probably doing something wrong. don't hurt me!