### PR TITLE
Update Package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "author": "Luigi Pinca",
   "license": "MIT",
   "scripts": {
-    "minify": "for f in public/js/{app,home,leaderboards}; do uglifyjs $f.js -o $f.min.js; done",
+    "minify": "for f in *.js; do short=${f%.js}; uglifyjs $f > $short.min.js; done",
     "import-data": "node util/load_sample_tracks.js",
     "start": "node app.js"
   },


### PR DESCRIPTION
Ubuntu 14.04
Node v7.7.3
Npm v4.1.2

Minify was returning multiple errors. Ran smoothly with the minify script portion modified to this.

Don't have the error on log anymore, but I believe it was unable to read the {app,home,leaderboards} portion.