### PR TITLE
Update Leaderboard javascript for less strict scroll checks.

### DIFF
--- a/public/js/leaderboards.js
+++ b/public/js/leaderboards.js
@@ -25,7 +25,7 @@
     $(this).scroll(function() {
       var diff = $(this).prop('scrollHeight') - $(this).scrollTop();
 
-      if (diff === $(this).height() && offset < 180) {
+      if (diff > $(this).height() - 2 && offset < 180) {
         offset += 30;
         $loading.show();
         $.get('/sliceleaderboard', { begin: offset, by: type }, function(data) {


### PR DESCRIPTION
The check was too strict and prevented leaderboard update calls.